### PR TITLE
Fix CI lock file error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,21 @@ jobs:
 
     - name: Install dependencies in ai-dual-mode
       working-directory: ./ai-dual-mode
-      run: npm ci
+      run: |
+        if [ -f package-lock.json ]; then
+          npm ci
+        else
+          npm install
+        fi
 
     - name: Install dependencies in ai-test-framework
       working-directory: ./ai-test-framework
-      run: npm ci
+      run: |
+        if [ -f package-lock.json ]; then
+          npm ci
+        else
+          npm install
+        fi
 
     - name: Lint ai-dual-mode
       working-directory: ./ai-dual-mode


### PR DESCRIPTION
## Summary
- update CI workflow to gracefully handle missing `package-lock.json`

## Testing
- `npm test`