### PR TITLE
Add simple AI test framework package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "test": "node test.js",
+    "test": "npm run test -w @cognitive/test-framework",
     "build": "npm run build -w @cognitive/dual-mode && npm run build -w @cognitive/requirements && npm run build -w @cognitive/test-framework",
     "example:ide-driven": "node examples/ide-driven",
     "example:ai-driven": "node examples/ai-driven",

--- a/packages/test-framework/__tests__/processor.test.js
+++ b/packages/test-framework/__tests__/processor.test.js
@@ -1,0 +1,16 @@
+const { TestProcessor } = require('../lib/processor');
+
+describe('TestProcessor', () => {
+  test('analyzeForIDE returns analyzed path', async () => {
+    const processor = new TestProcessor();
+    const result = await processor.analyzeForIDE('my-project');
+    expect(result).toEqual({ analyzed: 'my-project' });
+  });
+
+  test('processAIResponse maps ai output', async () => {
+    const processor = new TestProcessor();
+    const response = { choices: [{ message: { content: 'test content' } }] };
+    const result = await processor.processAIResponse(response, 'path');
+    expect(result).toEqual({ projectPath: 'path', generated: 'test content' });
+  });
+});

--- a/packages/test-framework/bin/cli.js
+++ b/packages/test-framework/bin/cli.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+'use strict';
+
+const { DualMode } = require('@cognitive/dual-mode');
+const { TestProcessor } = require('../lib/processor');
+
+/**
+ * Run the test framework CLI.
+ * Processes the given project path in IDE or API mode.
+ */
+function runCLI(args = process.argv.slice(2)) {
+  const projectPath = args[0] || process.cwd();
+  const mode = process.env.TEST_FRAMEWORK_MODE || 'ide';
+  const tool = DualMode.create('test-framework', new TestProcessor(), { mode });
+  return tool.process(projectPath);
+}
+
+if (require.main === module) {
+  runCLI().then(result => {
+    console.log(JSON.stringify(result, null, 2));
+  }).catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = { runCLI };

--- a/packages/test-framework/index.js
+++ b/packages/test-framework/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const { TestProcessor } = require('./lib/processor');
+const { runCLI } = require('./bin/cli');
+
+module.exports = {
+  TestProcessor,
+  runCLI
+};

--- a/packages/test-framework/lib/processor.js
+++ b/packages/test-framework/lib/processor.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/**
+ * TestProcessor - minimal AI-powered testing processor.
+ * In IDE mode it performs a simple analysis, while in API mode it
+ * prepares a prompt for an AI service and processes the mock response.
+ */
+class TestProcessor {
+  async analyzeForIDE(projectPath) {
+    return { analyzed: projectPath };
+  }
+
+  async prepareForAPI(projectPath) {
+    return { prompt: `Generate tests for ${projectPath}` };
+  }
+
+  async processAIResponse(aiResponse, projectPath) {
+    const content = aiResponse.choices?.[0]?.message?.content || '';
+    return { projectPath, generated: content };
+  }
+}
+
+module.exports = { TestProcessor };

--- a/packages/test-framework/package.json
+++ b/packages/test-framework/package.json
@@ -3,8 +3,11 @@
   "version": "0.1.0",
   "description": "AI-Powered Testing framework for generating and validating tests with AI assistance",
   "main": "index.js",
+  "bin": {
+    "cogtest": "bin/cli.js"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "build": "echo \"Building test-framework\""
   },
   "repository": {


### PR DESCRIPTION
## Summary
- implement basic test framework processor and CLI
- expose new functions from `@cognitive/test-framework`
- add Jest tests for the processor
- update package scripts to run tests

## Testing
- `npm test` *(fails: jest not found)*